### PR TITLE
Replace ssmtp with msmtp due to deprecation and compatibility issues with modern SMTP servers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ENV SMTP_FROM_ADDRESS="info@example.org"
 ENV SMTP_FROM_NAME="Example"
 ENV SMTP_REPLY_TO_ADDRESS="info@example.org"
 ENV SMTP_PROTOCOL="tls"
-ENV SMTP_TLS="YES"
+ENV SMTP_TLS="on"
 
 EXPOSE 80
 
@@ -36,14 +36,14 @@ COPY ./assets/99-overrides.ini /usr/local/etc/php/conf.d
 COPY ./assets/docker-entrypoint.sh /usr/local/bin
 
 RUN apt-get update \
-    && apt-get install -y libfreetype-dev libjpeg62-turbo-dev libpng-dev unzip wget nano ssmtp mailutils \
+    && apt-get install -y libfreetype-dev libjpeg62-turbo-dev libpng-dev unzip wget nano msmtp mailutils \
 	&& curl -sSL https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions -o - | sh -s \
       curl gd intl ldap mbstring mysqli xdebug odbc pdo pdo_mysql xml zip exif gettext bcmath csv event imap inotify mcrypt redis \
     && docker-php-ext-enable xdebug \
     && wget https://github.com/alextselegidis/easyappointments/releases/download/${VERSION}/easyappointments-${VERSION}.zip \
     && unzip easyappointments-${VERSION}.zip \
     && rm easyappointments-${VERSION}.zip \
-    && echo "sendmail_path=/usr/sbin/ssmtp -t" >> /usr/local/etc/php/conf.d/php-sendmail.ini \
+    && echo "sendmail_path=/usr/sbin/msmtp -t" >> /usr/local/etc/php/conf.d/php-sendmail.ini \
     && echo "alias ll=\"ls -al\"" >> /root/.bashrc \
     && apt-get -y autoremove \
     && apt-get clean \

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ volumes:
 
 You can use the following SMTP environment variables 
 
+```
 - SMTP_HOST="smtp.example.org"
 - SMTP_PORT="587"
 - SMTP_AUTH="1"
@@ -120,7 +121,8 @@ You can use the following SMTP environment variables
 - SMTP_FROM_NAME="Example"
 - SMTP_REPLY_TO_ADDRESS="info@example.org"
 - SMTP_PROTOCOL="tls"
-- SMTP_TLS="YES"
+- SMTP_TLS="on"
+```
 
 ## License 
 

--- a/assets/docker-entrypoint.sh
+++ b/assets/docker-entrypoint.sh
@@ -42,14 +42,17 @@ sed -i "s|const GOOGLE_API_KEY = '';|const GOOGLE_API_KEY = '$GOOGLE_API_KEY';|g
 
 # SMTP
 
-cat <<EOF >/etc/ssmtp/ssmtp.conf
-root=${SMTP_FROM_ADDRESS}
-mailhub=${SMTP_HOST}:${SMTP_PORT}
-AuthUser=${SMTP_USERNAME}
-AuthPass=${SMTP_PASSWORD}
-UseTLS=${SMTP_TLS}
-UseSTARTTLS=${SMTP_TLS}
-FromLineOverride=YES
+cat <<EOF >/etc/msmtprc
+account default
+host ${SMTP_HOST}
+port ${SMTP_PORT}
+from ${SMTP_FROM_ADDRESS}
+auth on
+user ${SMTP_USERNAME}
+password ${SMTP_PASSWORD}
+tls ${SMTP_TLS}
+tls_trust_file /etc/ssl/certs/ca-certificates.crt
+logfile ~/.msmtp.log
 EOF
 
 cat <<EOF >/var/www/html/application/config/email.php


### PR DESCRIPTION
This pull request replaces the deprecated `ssmtp` package with `msmtp` to resolve an issue I was having where `ssmtp` could not login into Oracle Cloud's SMTP server because of a lack of the latest encryption options.

When trying to log in into Oracle Cloud's SMTP server, I would get this error:

```
ssmtp: Server didn't like our AUTH LOGIN (504 The requested authentication mechanism is not supported)
```

After some debugging I found that it was because `ssmtp` was not updated to support the latest encryption options required by my cloud service.

According to Debian's package documentation, this package has not been maintained since 2019-03-19:
<https://wiki.debian.org/sSMTP>

`msmtp` is a drop-in replacement for `ssmtp`, offering better support for modern cryptographic protocols, enhanced security, and compatibility with newer SMTP servers:
<https://wiki.debian.org/msmtp>

